### PR TITLE
Add input validation for drawdown plan service

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -436,7 +436,7 @@ function AppContent() {
                 if (thresholdUnderPivot < y.domain()[1] && thresholdUnderPivot > y.domain()[0]) {
                   svg.append("line")
                     .attr("x1", 0)
-                    .attr("x2", xAtPivot)
+                    .attr("x2", xAtPivot!)
                     .attr("y1", yValueUnderPivot)
                     .attr("y2", yValueUnderPivot)
                     .attr("stroke", strokeColor)
@@ -446,7 +446,7 @@ function AppContent() {
                 // Segment at or after pivot age
                 if (thresholdAtOrOverPivot < y.domain()[1] && thresholdAtOrOverPivot > y.domain()[0]) {
                   svg.append("line")
-                    .attr("x1", xAtPivot)
+                    .attr("x1", xAtPivot!)
                     .attr("x2", width)
                     .attr("y1", yValueAtOrOverPivot)
                     .attr("y2", yValueAtOrOverPivot)

--- a/src/components/drawdown-plan-form.tsx
+++ b/src/components/drawdown-plan-form.tsx
@@ -31,7 +31,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Checkbox } from "@/components/ui/checkbox";
 import { NumericFormat } from 'react-number-format'; // Import NumericFormat
-import { defaultFormValues } from "@/lib/form-schema"; // Import the schema and defaults
+import { defaultFormValues, formSchema } from "@/lib/form-schema"; // Import the schema and defaults
 import { notDeepEqual } from "assert";
 
   
@@ -104,64 +104,6 @@ const months = [
     { value: '12', label: 'December' },
 ];
   
-  export const formSchema = z.object({
-    about: z.object({
-      age: z.coerce.number().min(18, { message: "Age must be at least 18" }).max(120, { message: "Age must be at most 120" }),
-      birth_month: z.string().refine((val) => {
-        const num = parseInt(val);
-        return !isNaN(num) && num >= 1 && num <= 12;
-      }, { message: "Month must be between 1 and 12" }),
-      end_of_plan_age: z.coerce.number().min(18, { message: "Age must be at least 18" }).max(120, { message: "Age must be at most 120" }),
-      filing_status: z.enum(["Single", "MFJ"]),
-      state_of_residence: z.string().min(2).max(2),
-    }),
-    social_security: z.object({
-      amount: z.coerce.number().min(0, { message: "Cannot be negative" }).max(15000, { message: "This should be a monthly amount." }),
-      starts: z.coerce.number().min(-1).max(70),
-    }),
-    predictions: z.object({
-      inflation: z.coerce.number().min(0, { message: "Cannot be negative" }).max(20, { message: "Must be 20% or less" }),
-      returns: z.coerce.number().min(-20, { message: "Must be -20% or more" }).max(50, { message: "Must be 50% or less" }),
-    }),
-    cash: z.object({
-      amount: z.coerce.number().min(0, { message: "Cannot be negative" }),
-    }),
-    brokerage: z.object({
-      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      basis: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      distributions: z.coerce.number().min(0, { message: "Cannot be negative" }).max(100, { message: "Must be 100% or less" }),
-    }),
-    IRA: z.object({
-      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
-    }),
-    Roth: z.object({
-      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      old_conversions: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      conversion_year_minus_1: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      conversion_year_minus_2: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      conversion_year_minus_3: z.coerce.number().min(0, { message: "Cannot be negative" }),
-      conversion_year_minus_4: z.coerce.number().min(0, { message: "Cannot be negative" }),
-
-    }),
-    ACA: z.object({
-      premium: z.coerce.number().min(0, { message: "Cannot be negative" }).max(10000, { message: "This should be a monthly amount." }),
-      slcsp: z.coerce.number().min(0, { message: "Cannot be negative" }).max(10000, { message: "This should be a monthly amount." }),
-      people_covered: z.coerce.number().min(1, { message: "Must cover at least 1 person" }).max(8, { message: "Can cover up to 8 people" }).optional(),
-    }).optional(),
-    roth_conversion_preference: z.enum(["anytime", "before_socsec", "never"]),
-    spending_preference: z.enum(["max_spend", "max_assets"]),
-    annual_spending: z.coerce.number().min(0, { message: "Cannot be negative" }).optional(),
-    pessimistic: z.object({
-      taxes: z.boolean(),
-      healthcare: z.boolean(),
-    }),
-  }).refine((schema) => 
-    (schema.social_security.starts >= schema.about.age) ||
-    schema.social_security.starts === -1, { 
-    message: "Make a selection",
-    path: ["social_security.starts"]
-});
-
   interface DrawdownPlanFormProps {
     onSubmit: (data: DrawdownPlanInput) => Promise<void>;
     onFormEdit: () => void; // Add the new prop

--- a/src/lib/form-schema.ts
+++ b/src/lib/form-schema.ts
@@ -1,5 +1,62 @@
 import * as z from "zod";
-import { formSchema } from "@/components/drawdown-plan-form";
+
+export const formSchema = z.object({
+    about: z.object({
+      age: z.coerce.number().min(18, { message: "Age must be at least 18" }).max(120, { message: "Age must be at most 120" }),
+      birth_month: z.string().refine((val) => {
+        const num = parseInt(val);
+        return !isNaN(num) && num >= 1 && num <= 12;
+      }, { message: "Month must be between 1 and 12" }),
+      end_of_plan_age: z.coerce.number().min(18, { message: "Age must be at least 18" }).max(120, { message: "Age must be at most 120" }),
+      filing_status: z.enum(["Single", "MFJ"]),
+      state_of_residence: z.string().min(2).max(2),
+    }),
+    social_security: z.object({
+      amount: z.coerce.number().min(0, { message: "Cannot be negative" }).max(15000, { message: "This should be a monthly amount." }),
+      starts: z.coerce.number().min(-1).max(70),
+    }),
+    predictions: z.object({
+      inflation: z.coerce.number().min(0, { message: "Cannot be negative" }).max(20, { message: "Must be 20% or less" }),
+      returns: z.coerce.number().min(-20, { message: "Must be -20% or more" }).max(50, { message: "Must be 50% or less" }),
+    }),
+    cash: z.object({
+      amount: z.coerce.number().min(0, { message: "Cannot be negative" }),
+    }),
+    brokerage: z.object({
+      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      basis: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      distributions: z.coerce.number().min(0, { message: "Cannot be negative" }).max(100, { message: "Must be 100% or less" }),
+    }),
+    IRA: z.object({
+      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
+    }),
+    Roth: z.object({
+      balance: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      old_conversions: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      conversion_year_minus_1: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      conversion_year_minus_2: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      conversion_year_minus_3: z.coerce.number().min(0, { message: "Cannot be negative" }),
+      conversion_year_minus_4: z.coerce.number().min(0, { message: "Cannot be negative" }),
+
+    }),
+    ACA: z.object({
+      premium: z.coerce.number().min(0, { message: "Cannot be negative" }).max(10000, { message: "This should be a monthly amount." }),
+      slcsp: z.coerce.number().min(0, { message: "Cannot be negative" }).max(10000, { message: "This should be a monthly amount." }),
+      people_covered: z.coerce.number().min(1, { message: "Must cover at least 1 person" }).max(8, { message: "Can cover up to 8 people" }).optional(),
+    }).optional(),
+    roth_conversion_preference: z.enum(["anytime", "before_socsec", "never"]),
+    spending_preference: z.enum(["max_spend", "max_assets"]),
+    annual_spending: z.coerce.number().min(0, { message: "Cannot be negative" }).optional(),
+    pessimistic: z.object({
+      taxes: z.boolean(),
+      healthcare: z.boolean(),
+    }),
+  }).refine((schema) =>
+    (schema.social_security.starts >= schema.about.age) ||
+    schema.social_security.starts === -1, {
+    message: "Make a selection",
+    path: ["social_security.starts"]
+});
 
 export const defaultFormValues: z.infer<typeof formSchema> = {
     about: { age: 59, birth_month: "1", end_of_plan_age: 89, filing_status: "Single", state_of_residence: "FL" },

--- a/src/services/drawdown-plan.ts
+++ b/src/services/drawdown-plan.ts
@@ -1,3 +1,5 @@
+import { formSchema } from "@/lib/form-schema";
+
 /**
  * Represents the user's input data for generating a drawdown plan.
  */
@@ -278,6 +280,9 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || process.env.REACT_APP_AP
  * @returns A promise that resolves to a DrawdownPlanResponse.
  */
 export async function calculateDrawdownPlan(payload: any): Promise<DrawdownPlanResponse> {
+  // Validate the payload against the schema to ensure data integrity
+  const validatedPayload = formSchema.parse(payload);
+
   const calculateUrl = `${API_BASE_URL}/calculate`; // Construct the URL
 
   const response = await fetch(calculateUrl, { // Use the constructed URL
@@ -285,7 +290,7 @@ export async function calculateDrawdownPlan(payload: any): Promise<DrawdownPlanR
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(validatedPayload),
   });
   // console.log(response);
   if (!response.ok) {


### PR DESCRIPTION
Refactored `formSchema` to `src/lib/form-schema.ts` to centralize validation logic. Updated `src/components/drawdown-plan-form.tsx` to import the schema. Added input validation to `calculateDrawdownPlan` in `src/services/drawdown-plan.ts` using `formSchema.parse()` to ensure data integrity before backend communication. Fixed TypeScript errors in `src/app/page.tsx` related to D3 scale return types. This enhances security by preventing malformed payloads from reaching the backend and improves codebase maintainability.

---
*PR created automatically by Jules for task [18362738798371220690](https://jules.google.com/task/18362738798371220690) started by @hubcity*