### PR TITLE
⚡ Bolt: Optimize DrawdownPlanForm rendering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from 'react'; // Import React for Fragment
 import Link from 'next/link';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Menu } from 'lucide-react';
 import {
   Sidebar,
@@ -612,7 +612,9 @@ function AppContent() {
     }
   }, [drawdownPlan]);
 
-  const handleSubmit = async (input: DrawdownPlanInput) => {
+  const handleFormEdit = useCallback(() => setIsFormEdited(true), []);
+
+  const handleSubmit = useCallback(async (input: DrawdownPlanInput) => {
     // console.log(input);
     setErrorMessage(null); // Clear any previous error messages
     const apiPayload = {
@@ -725,7 +727,7 @@ function AppContent() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
   const handleAcceptTerms = () => {
     setHasAcceptedTerms(true);
     // setShowFieldDescriptions(true); // Show field descriptions
@@ -754,7 +756,7 @@ function AppContent() {
             <SidebarContent>
             <DrawdownPlanForm
               onSubmit={handleSubmit}
-              onFormEdit={() => setIsFormEdited(true)} // Pass the callback
+              onFormEdit={handleFormEdit} // Pass the callback
             />
           </SidebarContent>
         </div>

--- a/src/components/drawdown-plan-form.tsx
+++ b/src/components/drawdown-plan-form.tsx
@@ -8,7 +8,7 @@ import {
   } from "@/services/drawdown-plan";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useWatch, useFormState } from "react-hook-form";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, memo, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
   
@@ -167,7 +167,7 @@ const months = [
     onFormEdit: () => void; // Add the new prop
   }
   
-  export function DrawdownPlanForm({ onSubmit, onFormEdit }: DrawdownPlanFormProps) {
+  const DrawdownPlanFormInner = ({ onSubmit, onFormEdit }: DrawdownPlanFormProps) => {
     const form = useForm<z.infer<typeof formSchema>>({
       resolver: zodResolver(formSchema),
       defaultValues: defaultFormValues, // Use the imported defaults
@@ -176,8 +176,8 @@ const months = [
     const [formValues, setFormValues] = useState<DrawdownPlanInput | null>(null);
     const currentYear = 2026;
     const currentAge = useWatch({control: form.control, name: "about.age"});
-    const socialSecurityStartAges = Array.from({ length: 71 - (Number(currentAge)) }, (_, i) => Number(currentAge) + i);
-    const conversionYears = Array.from({ length: 4 }, (_, i) => currentYear - 1 - i);
+    const socialSecurityStartAges = useMemo(() => Array.from({ length: 71 - (Number(currentAge)) }, (_, i) => Number(currentAge) + i), [currentAge]);
+    const conversionYears = useMemo(() => Array.from({ length: 4 }, (_, i) => currentYear - 1 - i), []);
     const cashInputRef = useRef<HTMLInputElement>(null); // Create a ref for the cash input
     const [hasErrors, setHasErrors] = useState(false); // To style the button
     // const [isFormEdited, setIsFormEdited] = useState(false); // Local state for form edit, managed by onFormEdit prop
@@ -1101,4 +1101,6 @@ const months = [
         </form>
       </Form>
     );
-  }
+  };
+
+  export const DrawdownPlanForm = memo(DrawdownPlanFormInner);


### PR DESCRIPTION
⚡ Bolt: Optimized DrawdownPlanForm rendering

💡 What:
- Memoized `DrawdownPlanForm` component using `React.memo`.
- Memoized `socialSecurityStartAges` and `conversionYears` calculations inside the form using `useMemo`.
- Wrapped `handleSubmit` and created `handleFormEdit` using `useCallback` in `src/app/page.tsx` to ensure stable props are passed to the form.

🎯 Why:
- The `DrawdownPlanForm` was re-rendering on every parent render (e.g., when loading state changed or error messages appeared) because the `onFormEdit` prop was an inline function.
- Expensive array calculations inside the form were running on every render.
- This caused unnecessary DOM updates and computations, impacting UI responsiveness especially on lower-end devices.

📊 Impact:
- Reduces re-renders of the `DrawdownPlanForm` significantly.
- Eliminates recalculation of ~70-element array on every render.
- Improves perceived performance when interacting with other parts of the UI that trigger parent updates.

🔬 Measurement:
- Verified that the form still renders correctly and is interactive using Playwright.
- Verified that error handling still works as expected.
- Verified that type checking passes (ignoring pre-existing errors).

---
*PR created automatically by Jules for task [15605333695572012738](https://jules.google.com/task/15605333695572012738) started by @hubcity*