### PR TITLE
🎨 Palette: Add ARIA labels to tooltip triggers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-01 - Add ARIA Labels to TooltipTriggers
+**Learning:** Icon-only buttons using Radix UI `TooltipTrigger` (e.g., wrapping `Info` or `AlertTriangle` from `lucide-react`) lack accessible names by default and require explicit `aria-label` attributes for screen reader compatibility.
+**Action:** Always add descriptive `aria-label`s to `TooltipTrigger` or generic icon-only `<button>`s when adding or modifying them in this design system.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4562,7 +4562,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"

--- a/src/components/drawdown-plan-form.tsx
+++ b/src/components/drawdown-plan-form.tsx
@@ -282,7 +282,7 @@ const months = [
                 <FormLabel>{`Age (end of ${currentYear})`}</FormLabel>
                 <TooltipProvider>
                   <Tooltip>
-                    <TooltipTrigger
+                    <TooltipTrigger aria-label="Warning information"
                       type="button"
                       onClick={(e) => e.stopPropagation()} // Prevent form submission
                     ><AlertTriangle size={16} className="text-yellow-700" onClick={(e) => e.stopPropagation()} // Prevent form submission
@@ -470,7 +470,7 @@ const months = [
                   <FormLabel>Cash</FormLabel>
                   <TooltipProvider>
                     <Tooltip>
-                      <TooltipTrigger type="button" onClick={(e) => e.stopPropagation()}>
+                      <TooltipTrigger aria-label="More information" type="button" onClick={(e) => e.stopPropagation()}>
                         <Info size={16} className="text-blue-600" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs break-words">Readily available cash where a withdrawal is not subject to tax, such as your checking account balance.</TooltipContent>
@@ -550,7 +550,7 @@ const months = [
                 <FormLabel>Cost Basis</FormLabel>
                 <TooltipProvider>
                     <Tooltip>
-                        <TooltipTrigger
+                        <TooltipTrigger aria-label="Warning information"
                           type="button"
                           onClick={(e) => e.stopPropagation()} // Prevent form submission
                       ><AlertTriangle size={16} className="text-yellow-700" onClick={(e) => e.stopPropagation()} // Prevent form submission
@@ -593,7 +593,7 @@ const months = [
                   <FormLabel>Distributions</FormLabel>
                   <TooltipProvider>
                     <Tooltip>
-                      <TooltipTrigger type="button" onClick={(e) => e.stopPropagation()}>
+                      <TooltipTrigger aria-label="More information" type="button" onClick={(e) => e.stopPropagation()}>
                         <Info size={16} className="text-blue-600" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs break-words">Percentage of the account paid out annually regardless of withdrawals.</TooltipContent>
@@ -671,7 +671,7 @@ const months = [
                     </FormLabel>
                 <TooltipProvider>
                     <Tooltip>
-                        <TooltipTrigger
+                        <TooltipTrigger aria-label="Warning information"
                           type="button"
                           onClick={(e) => e.stopPropagation()} // Prevent form submission
                       ><AlertTriangle size={16} className="text-yellow-700" onClick={(e) => e.stopPropagation()} // Prevent form submission
@@ -724,7 +724,7 @@ const months = [
                       {index === 0 && ( // Only add tooltip for the first field (conversion_year_minus_1)
                         <TooltipProvider>
                           <Tooltip>
-                            <TooltipTrigger type="button" onClick={(e) => e.stopPropagation()}>
+                            <TooltipTrigger aria-label="More information" type="button" onClick={(e) => e.stopPropagation()}>
                               <Info size={16} className="text-blue-600" />
                             </TooltipTrigger>
                             <TooltipContent className="max-w-xs break-words">For each year enter the amount of additions (contributions or conversions) made to the account that have not yet been withdrawn.</TooltipContent>
@@ -769,7 +769,7 @@ const months = [
                   <FormLabel>Older Roth Additions</FormLabel>
                   <TooltipProvider>
                     <Tooltip>
-                      <TooltipTrigger type="button" onClick={(e) => e.stopPropagation()}>
+                      <TooltipTrigger aria-label="More information" type="button" onClick={(e) => e.stopPropagation()}>
                         <Info size={16} className="text-blue-600" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs break-words">If you are older than 59.5 and your Roth account has been open for more than 5 years, enter 1; otherwise enter the amount of older additions that have not yet been withdrawn.</TooltipContent>
@@ -838,7 +838,7 @@ const months = [
         <FormLabel>Monthly Benefit</FormLabel>
                 <TooltipProvider>
                   <Tooltip>
-                    <TooltipTrigger
+                    <TooltipTrigger aria-label="Warning information"
                       type="button"
                       onClick={(e) => e.stopPropagation()} // Prevent form submission
                     ><AlertTriangle size={16} className="text-yellow-700" onClick={(e) => e.stopPropagation()} // Prevent form submission
@@ -916,7 +916,7 @@ const months = [
             <FormLabel>SLCSP Monthly</FormLabel>
             <TooltipProvider>
               <Tooltip>
-                <TooltipTrigger
+                <TooltipTrigger aria-label="Warning information"
                   type="button"
                   onClick={(e) => e.stopPropagation()} // Prevent form submission
                 ><AlertTriangle size={16} className="text-yellow-700" onClick={(e) => e.stopPropagation()} // Prevent form submission


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to `TooltipTrigger` elements acting as icon-only buttons in `DrawdownPlanForm`.
🎯 **Why:** Screen readers could not announce the purpose of these warning and informational tooltips because they only contained SVG icons.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Form fields with tooltips are now fully navigable and understandable by keyboard and screen reader users.

---
*PR created automatically by Jules for task [17627317720938121614](https://jules.google.com/task/17627317720938121614) started by @hubcity*